### PR TITLE
API change: WritableStreamBuffer now returns empty Buffer or empty

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,5 +1,9 @@
 This file contains the changes by version since the fork
 ========================================================
+v3.3.0
+    - API change: WritableStreamBuffer now returns empty Buffer or empty String when calling getContents() or
+      getContentsAsString() respectively. Old API was to return boolean false
+
 v3.2.0
     - Library uses some ES6 features
     - WritableStreamBuffer when overflowing the limit, if set, now throws BufferOverflowError

--- a/lib/writable_streambuffer.js
+++ b/lib/writable_streambuffer.js
@@ -27,7 +27,7 @@ const WritableStreamBuffer = module.exports = function(opts) {
   };
 
   this.getContents = function(length) {
-    if(!size) return false;
+    if(!size) return new Buffer('');
 
     const data = new Buffer(Math.min(length || size, size));
     buffer.copy(data, 0, 0, data.length);
@@ -41,7 +41,7 @@ const WritableStreamBuffer = module.exports = function(opts) {
   };
 
   this.getContentsAsString = function(encoding, length) {
-    if(!size) return false;
+    if(!size) return '';
 
     const data = buffer.toString(encoding || 'utf8', 0, Math.min(length || size, size));
     const dataLength = Buffer.byteLength(data);

--- a/test/writable_streambuffer.test.js
+++ b/test/writable_streambuffer.test.js
@@ -11,12 +11,13 @@ describe('WritableStreamBuffer with defaults', function() {
     this.buffer = new streamBuffer.WritableStreamBuffer();
   });
 
-  it('returns false on call to getContents() when empty', function() {
-    return expect(this.buffer.getContents()).to.be.false;
+  it('returns empty Buffer on call to getContents() when empty', function() {
+    const emptyBuffer = new Buffer('');
+    return expect(this.buffer.getContents()).to.be.deep.equal(emptyBuffer);
   });
 
-  it('returns false on call to getContentsAsString() when empty', function() {
-    return expect(this.buffer.getContentsAsString()).to.be.false;
+  it('returns empty string on call to getContentsAsString() when empty', function() {
+    return expect(this.buffer.getContentsAsString()).to.be.equal('');
   });
 
   it('backing buffer should be default size', function() {


### PR DESCRIPTION
String when calling getContents() or getContentsAsString() respectively